### PR TITLE
Enhancement: Allow use of disabled placeholder with validated select

### DIFF
--- a/addon/components/validated-select.js
+++ b/addon/components/validated-select.js
@@ -15,10 +15,12 @@ export default Ember.Component.extend(validatedBase, {
   }),
 
   defaultChoice: Ember.computed(function() {
+    if (this.get('placeholder')) { return; }
     return this.get("fieldObj").choices[0];
   }),
 
   remainingChoices: Ember.computed(function() {
+    if (this.get('placeholder')) { return Ember.A(this.get("fieldObj").choices); }
     return Ember.A(this.get("fieldObj").choices.slice(1, 100));
   }),
 

--- a/app/templates/components/validated-select.hbs
+++ b/app/templates/components/validated-select.hbs
@@ -4,8 +4,12 @@
   {{/if}}
 {{/if}}
 
-<select id="{{_id}}">
-  <option value="{{defaultChoice}}" selected="selected">{{defaultChoice}}</option>
+<select id="{{_id}}" class="{{_class}}">
+  {{#if placeholder}}
+    <option id="validated-select-placeholder" disabled selected>{{placeholder}}</option>
+  {{else}}
+    <option value="{{defaultChoice}}" selected="selected">{{defaultChoice}}</option>
+  {{/if}}
   {{#each remainingChoices as |choice|}}
     <option value="{{choice}}">{{choice}}</option>
   {{/each}}

--- a/tests/acceptance/form-one-test.js
+++ b/tests/acceptance/form-one-test.js
@@ -54,3 +54,11 @@ test("Select field does display an error if selected field does not matche regex
   fillIn("#love", "None");
   andThen(function() { assert.ok(find("#loveError").length); });
 });
+
+test("Select field with placeholder selects it as a disabled option", function(assert) {
+  visit("/form-one");
+  andThen(function() {
+    assert.ok(find("#validated-select-placeholder").is(':selected'));
+    assert.ok(find("#validated-select-placeholder").is(':disabled'));
+  });
+});

--- a/tests/dummy/app/controllers/form-one.js
+++ b/tests/dummy/app/controllers/form-one.js
@@ -5,10 +5,11 @@ export default Ember.Controller.extend({
   init: function() {
     // Tests carry state if this is not defined in init
     this.set("formFields", Ember.A([
-    {_id: "name"   , regex: /^[A-Za-z]+$/},
-    {_id: "zipCode", regex: /^\d+$/},
-    {_id: "cool"   , regex: /true/},
-    {_id: "love"   , regex: /Lots|Some/, choices: Ember.A(["----", "Lots", "Some", "None"])}]));
+    {_id: "name",        regex: /^[A-Za-z]+$/},
+    {_id: "zipCode",     regex: /^\d+$/},
+    {_id: "cool",        regex: /true/},
+    {_id: "love",        regex: /Lots|Some/, choices: Ember.A(["----", "Lots", "Some", "None"])},
+    {_id: "placeholder", regex: /none/,      choices: Ember.A(["I don't love them", ])}]));
   },
 
   actions: {

--- a/tests/dummy/app/templates/form-one.hbs
+++ b/tests/dummy/app/templates/form-one.hbs
@@ -24,6 +24,13 @@
   {{/validated-select}}
 </div>
 
+<div>
+  How do you feel about placeholders?
+  {{#validated-select _id="placeholder" formFields=formFields contentPosition="after" placeholder="I love them"}}
+    <div id="liar">Yes you do</div>
+  {{/validated-select}}
+</div>
+
 <button id="formValid" {{action "formValid"}}>Form Valid?</button>
 <button id="markInvalid" {{action "markInvalid"}}>Mark Invalid</button>
 <button id="formData" {{action "formData"}}>Log Form Data</button>


### PR DESCRIPTION
Tried to keep this as close to a non-breaking change as possible. If the user doesn't have a placeholder it will behave in the exact same way that it did previously, otherwise it will return the full list of choices as `remainingChoices` and `defaultChoice` won't happen.