### PR TITLE
Bug Fix: Remove duplicate select values with default value

### DIFF
--- a/addon/components/validated-select.js
+++ b/addon/components/validated-select.js
@@ -24,8 +24,13 @@ export default Ember.Component.extend(validatedBase, {
   }),
 
   remainingChoices: Ember.computed(function() {
-    if (this.get('placeholder')) { return Ember.A(this.get("fieldObj").choices); }
-    return Ember.A(this.get("fieldObj").choices.slice(1, 100));
+    if (this.get('placeholder')) { return Ember.A(this.get('fieldObj').choices); }
+    if (this.get('fieldObj').value) {
+      var index = this.get('fieldObj').choices.indexOf(this.get('fieldObj').value);
+      this.get('fieldObj').choices.splice(index, 1);
+      return Ember.A(this.get('fieldObj').choices.slice(0, 100));
+    }
+    return Ember.A(this.get('fieldObj').choices.slice(1, 100));
   }),
 
   change: function(e) {

--- a/tests/acceptance/form-two-test.js
+++ b/tests/acceptance/form-two-test.js
@@ -20,3 +20,8 @@ test("Fields with valFunctions trigger do not have errors if provided desired in
   andThen(function() { find("#securityCode").focusout(); });
   andThen(function() { assert.ok(!find("#codeError").length); });
 });
+
+test("Select fields with a default value do not duplicate the value in the choices", function(assert) {
+  visit("/form-two");
+  andThen(function() { assert.equal(find("#cardExp option").text(), "10/1608/1609/16");});
+});

--- a/tests/dummy/app/controllers/form-two.js
+++ b/tests/dummy/app/controllers/form-two.js
@@ -5,7 +5,8 @@ export default Ember.Controller.extend({
   formFields: Ember.computed(function() {
     return Ember.A([
       {_id: "securityCode" , regex: /^\d{3,4}$/    , valFunction: this.get("codeCheck")},
-      {_id: "cardType"     , regex: /Amex|Discover/, choices: Ember.A(["----", "Amex", "Discover"])}
+      {_id: "cardType"     , regex: /Amex|Discover/, choices: Ember.A(["----", "Amex", "Discover"])},
+      {_id: "cardExp"      , regex: /^\d{2}\/\d{2}$/, choices: Ember.A(["08/16", "09/16", "10/16"]), value: "10/16"}
     ]);
   }),
 

--- a/tests/dummy/app/templates/form-two.hbs
+++ b/tests/dummy/app/templates/form-two.hbs
@@ -6,6 +6,13 @@
 </div>
 
 <div>
+  Already selected value
+  {{#validated-select _id="cardExp" formFields=formFields contentPosition="after"}}
+    <div id="cardError">Your card must expire</div>
+  {{/validated-select}}
+</div>
+
+<div>
   {{#validated-input _id="securityCode" formFields=formFields contentPosition="after" placeholder="Security Code"}}
     <div id="codeError">Invalid security code</div>
   {{/validated-input}}


### PR DESCRIPTION
A select box with a default value has that value duplicated if it is
also in the choices list. I was expecting that the value only be listed
once.